### PR TITLE
Adding -ltinfo for static compilation with glibc and making changes to adhere to C standards.

### DIFF
--- a/build/mk.config
+++ b/build/mk.config
@@ -134,7 +134,7 @@ LIBPATH = -L/usr/lib -L/usr/ccs/lib
 # does not supply our needs. Use -ltermcap instead and add -DUSE_TERMCAP
 # to CPPFLAGS.
 #
-LCURS = -lcurses
+LCURS = -lcurses -ltinfo
 
 #
 # Socket library, necessary on Solaris and Open UNIX. If your system has

--- a/chroot/chroot.c
+++ b/chroot/chroot.c
@@ -20,6 +20,11 @@
 
 char *progname;
 
+void usage(void) {
+	pfmt(stderr, MM_NOSTD, "usage: %s newroot [command]\n", progname);
+	exit(1);
+}
+
 int main(int argc, char *argv[]) {
 	progname = argv[0];	
 
@@ -44,9 +49,4 @@ int main(int argc, char *argv[]) {
 		prerror(errno);
 		exit(-1);
 	}
-}
-
-void usage(void) {
-	pfmt(stderr, MM_NOSTD, "usage: %s newroot [command]\n", progname);
-	exit(1);
 }

--- a/nawk/main.c
+++ b/nawk/main.c
@@ -53,7 +53,7 @@ int	mb_cur_max;	/* MB_CUR_MAX, for acceleration */
 
 extern const char badopen[];
 
-int main(int argc, unsigned char *argv[], unsigned char *envp[])
+int main(int argc, char *argv[], char *envp[])
 {
 	unsigned char *fs = NULL;
 	char label[MAXLABEL+1];	/* Space for the catalogue label */


### PR DESCRIPTION
Those changes are required to easily build Heirloom-ng on Debian 12 (Bookworm)
I have not tested those alterations on musl, but it should work as well